### PR TITLE
Wanted to setImageDrawable because there was only the setImageResource

### DIFF
--- a/squareprogressbar/src/ch/halcyon/squareprogressbar/SquareProgressBar.java
+++ b/squareprogressbar/src/ch/halcyon/squareprogressbar/SquareProgressBar.java
@@ -85,18 +85,29 @@ public class SquareProgressBar extends RelativeLayout {
 		bar.bringToFront();
 	}
 
-	/**
-	 * Sets the image of the {@link SquareProgressBar}. Must be a valid
-	 * ressourceId.
-	 * 
-	 * @param image
-	 *            the image as a ressourceId
-	 * @since 1.0
-	 */
-	public void setImage(int image) {
-		imageView.setImageResource(image);
+    /**
+     * Sets the image of the {@link SquareProgressBar}. Must be a valid
+     * ressourceId.
+     *
+     * @param image the image as a ressourceId
+     * @since 1.0
+     */
+    public void setImageResource(int image) {
+        imageView.setImageResource(image);
 
-	}
+    }
+
+    /**
+     * Sets the image of the {@link SquareProgressBar}. Must be a valid
+     * Drawable.
+     *
+     * @param image the image as a Drawable
+     * @since 1.0
+     */
+    public void setImage(Drawable image) {
+        imageView.setImageDrawable(image);
+
+    }
 
 	/**
 	 * Sets the image scale type according to {@link ScaleType}.


### PR DESCRIPTION
This is useful when using Picasso like this

Picasso.with(getActivity())
.load(imageURL)
.into(streetViewImage, new com.squareup.picasso.Callback() {
@Override
public void onSuccess() {
SquareProgressBar squareProgressBar = (SquareProgressBar)
getView().findViewById(R.id.search_street_view_image_SquareProgressBar);
ImageView streetViewImage = (ImageView)
getView().findViewById(R.id.search_street_view_image);
int id = Resources.getSystem().getIdentifier("ic_dialog_alert",
"drawable", "android");
squareProgressBar.setImage(streetViewImage.getDrawable());
squareProgressBar.setProgress(50.0);
squareProgressBar.setIndeterminate(true);
streetViewImage.setImageDrawable(null);
}

@Override
public void onError() {
//do smth when there is picture loading error
}
});